### PR TITLE
Update readme and permissions error text

### DIFF
--- a/R/github_api.R
+++ b/R/github_api.R
@@ -194,7 +194,7 @@ safe_gh <- function(fun, ...) {
         if (!is.null(repo_label)) {
           msg <- paste0(msg, " for ", repo_label)
         }
-        msg <- paste0(msg, "; falling back to empty result. Provide a PAT with repo + issues (read) scope for private repos.")
+        msg <- paste0(msg, "; falling back to empty result. For private repos, provide a fine-grained PAT with repository access and read permissions for Contents, Metadata, Issues, and Pull requests.")
         warning(msg, call. = FALSE)
         return(NULL)
       }

--- a/README.md
+++ b/README.md
@@ -103,8 +103,11 @@ The workflows optionally use the following repository secret:
 
 - `GH_DASH_REPOS` (optional): A fine-grained PAT used to access private repositories and (optionally) the qualification registry. If not provided, the workflow falls back to the default `github.token`, which only has access to public repositories.
 
-If you use a fine-grained PAT for `GH_DASH_REPOS`, grant access to the repositories you want to report on and the following repository permissions:
+If you use a fine-grained PAT for `GH_DASH_REPOS`, grant access to all repositories you want to report on (and to the qualification registry repository, if used), then grant the following repository permissions:
 
-- Contents: Read
-- Metadata: Read
-- Issues: Read (for issue/milestone data)
+- Contents: Read (releases, branch comparison, and optional qualification registry file)
+- Metadata: Read (repository metadata)
+- Issues: Read (milestones)
+- Pull requests: Read (open PR counts)
+
+For public repositories, `GH_DASH_REPOS` is optional. The workflow can use the default `github.token`, but it cannot access private repositories outside the workflow repository.


### PR DESCRIPTION
This pull request updates documentation and error messages to clarify the fine-grained Personal Access Token (PAT) permissions required for accessing GitHub repositories. It addresses issue https://github.com/Gilead-BioStats/gh.dash/issues/22 by providing more detailed and actionable guidance on the specific repository permissions needed.
- Closes #22 