### PR TITLE
Add open vs closed issues column to package status report

### DIFF
--- a/R/github_api.R
+++ b/R/github_api.R
@@ -64,6 +64,57 @@ fetch_branch_comparison <- function(owner, repo, base, head, token) {
   )
 }
 
+#' Fetch open and closed issue counts from GitHub API
+#'
+#' Internal function to retrieve issue totals for open and closed issues.
+#' Pull request counts are excluded (`is:issue` is used in search queries).
+#'
+#' @param owner Repository owner (GitHub username or organization)
+#' @param repo Repository name
+#' @param token GitHub personal access token (optional)
+#' @return List with `open` and `closed` counts or NULL when unavailable
+#' @keywords internal
+#' @importFrom gh gh
+fetch_issue_counts <- function(owner, repo, token) {
+  open_count <- fetch_issue_count_by_state(owner, repo, state = "open", token = token)
+  closed_count <- fetch_issue_count_by_state(owner, repo, state = "closed", token = token)
+
+  if (is.null(open_count) || is.null(closed_count)) {
+    return(NULL)
+  }
+
+  list(open = open_count, closed = closed_count)
+}
+
+#' Fetch issue count for a single state from GitHub API
+#'
+#' Internal function to retrieve issue count from GitHub search API.
+#'
+#' @param owner Repository owner (GitHub username or organization)
+#' @param repo Repository name
+#' @param state Issue state (`open` or `closed`)
+#' @param token GitHub personal access token (optional)
+#' @return Numeric count or NULL when unavailable
+#' @keywords internal
+#' @importFrom gh gh
+fetch_issue_count_by_state <- function(owner, repo, state, token) {
+  query <- sprintf("repo:%s/%s is:issue is:%s", owner, repo, state)
+
+  payload <- safe_gh(
+    gh::gh,
+    "GET /search/issues",
+    q = query,
+    per_page = 1,
+    .token = token
+  )
+
+  if (is.null(payload)) {
+    return(NULL)
+  }
+
+  sanitize_issue_count(payload$total_count)
+}
+
 #' Safe GitHub API wrapper
 #'
 #' Internal function that wraps GitHub API calls to handle 404 errors gracefully.

--- a/R/github_formatting.R
+++ b/R/github_formatting.R
@@ -300,6 +300,40 @@ format_branch_comparison <- function(owner, repo, comparison) {
   as.character(anchor)
 }
 
+#' Format open vs closed issue counts as HTML
+#'
+#' Internal function to format issue totals as a linked label.
+#'
+#' @param owner Repository owner (GitHub username or organization)
+#' @param repo Repository name
+#' @param issue_counts List with `open` and `closed` issue counts
+#' @return Character string with HTML anchor tag
+#' @keywords internal
+#' @importFrom htmltools tags HTML
+format_issue_summary <- function(owner, repo, issue_counts) {
+  issues_url <- sprintf("https://github.com/%s/%s/issues", owner, repo)
+
+  if (is.null(issue_counts)) {
+    label <- tailwind_label(
+      "Unavailable",
+      title = "Issue totals unavailable",
+      variant = "slate"
+    )
+    return(as.character(htmltools::tags$a(href = issues_url, htmltools::HTML(label))))
+  }
+
+  open_count <- sanitize_issue_count(issue_counts$open)
+  closed_count <- sanitize_issue_count(issue_counts$closed)
+
+  label <- tailwind_label(
+    sprintf("%s / %s", open_count, closed_count),
+    title = sprintf("%s open / %s closed issues", open_count, closed_count),
+    variant = "sky"
+  )
+
+  as.character(htmltools::tags$a(href = issues_url, htmltools::HTML(label)))
+}
+
 #' Get branch status text
 #'
 #' Internal function to convert GitHub branch comparison into readable status text.

--- a/R/summarize_github_repos.R
+++ b/R/summarize_github_repos.R
@@ -9,8 +9,8 @@
 #'   with columns `org`, `repo`, `version`, `release.url`, `release.date`,
 #'   `qualification.url`, and `qualification.date`.
 #'
-#' @return A data frame with columns `repo`, `latest_release`, `upcoming_milestones`, and
-#'   `dev_branch_status`.
+#' @return A data frame with columns `repo`, `latest_release`,
+#'   `open_vs_closed_issues`, `upcoming_milestones`, and `dev_branch_status`.
 #' @examples
 #' \dontrun{
 #' summarize_github_repos(c("tidyverse/ggplot2"))
@@ -36,12 +36,14 @@ summarize_github_repos <- function(
     repo <- pieces[[2]]
 
     release <- fetch_latest_release(owner, repo, token)
+    issue_counts <- fetch_issue_counts(owner, repo, token)
     milestones <- fetch_open_milestones(owner, repo, token)
     comparison <- fetch_branch_comparison(owner, repo, base = "main", head = "dev", token = token)
 
     results[[idx]] <- list(
       repo = format_repo_link(owner, repo),
       latest_release = format_release_summary(owner, repo, release, registry),
+      open_vs_closed_issues = format_issue_summary(owner, repo, issue_counts),
       upcoming_milestones = format_milestone_summary(owner, repo, milestones),
       dev_branch_status = format_branch_comparison(owner, repo, comparison)
     )
@@ -50,6 +52,7 @@ summarize_github_repos <- function(
   data.frame(
     repo = vapply(results, `[[`, character(1), "repo"),
     latest_release = vapply(results, `[[`, character(1), "latest_release"),
+    open_vs_closed_issues = vapply(results, `[[`, character(1), "open_vs_closed_issues"),
     upcoming_milestones = vapply(results, `[[`, character(1), "upcoming_milestones"),
     dev_branch_status = vapply(results, `[[`, character(1), "dev_branch_status"),
     stringsAsFactors = FALSE

--- a/inst/report/package_status_report.Rmd
+++ b/inst/report/package_status_report.Rmd
@@ -38,6 +38,7 @@ status <- if (length(repos) == 0L) {
   data.frame(
     repo = character(0),
     latest_release = character(0),
+    open_vs_closed_issues = character(0),
     upcoming_milestones = character(0),
     dev_branch_status = character(0),
     stringsAsFactors = FALSE
@@ -224,6 +225,10 @@ render_status_table <- function(df) {
       ),
       htmltools::tags$td(
         class = "status-table__cell",
+        htmltools::HTML(df$open_vs_closed_issues[[i]])
+      ),
+      htmltools::tags$td(
+        class = "status-table__cell",
         htmltools::HTML(df$upcoming_milestones[[i]])
       ),
       htmltools::tags$td(
@@ -244,6 +249,7 @@ render_status_table <- function(df) {
           htmltools::tags$tr(
             htmltools::tags$th(scope = "col", "Repository"),
             htmltools::tags$th(scope = "col", "Latest release"),
+            htmltools::tags$th(scope = "col", "Issues (open / closed)"),
             htmltools::tags$th(scope = "col", "Open milestones"),
             htmltools::tags$th(
               scope = "col",

--- a/tests/testthat/test-report-package-status.R
+++ b/tests/testthat/test-report-package-status.R
@@ -32,6 +32,11 @@ test_that("summarize_github_repos assembles release and milestone summaries", {
       expect_equal(repo, "repo")
       mock_release
     },
+    fetch_issue_counts = function(owner, repo, token) {
+      expect_equal(owner, "org")
+      expect_equal(repo, "repo")
+      list(open = 8, closed = 13)
+    },
     fetch_open_milestones = function(owner, repo, token) {
       expect_equal(owner, "org")
       expect_equal(repo, "repo")
@@ -49,6 +54,10 @@ test_that("summarize_github_repos assembles release and milestone summaries", {
   expect_match(result$latest_release, "<a href=\"https://github.com/org/repo/releases/tag/v1.0.0\">")
   expect_match(result$latest_release, "Released 2025-01-01")
   expect_match(result$latest_release, "span")
+  expect_equal(
+    result$open_vs_closed_issues,
+    "<a href=\"https://github.com/org/repo/issues\"><span class=\"badge badge--sky\" title=\"8 open / 13 closed issues\">8 / 13</span></a>"
+  )
   expect_equal(
     result$dev_branch_status,
     "<a href=\"https://github.com/org/repo/compare/main...dev\">+2, -1</a>"
@@ -78,6 +87,7 @@ test_that("summarize_github_repos appends qualification badge when registry matc
   result <- with_mocked_bindings(
     summarize_github_repos("org/repo", qualification_registry = registry),
     fetch_latest_release = function(...) mock_release,
+    fetch_issue_counts = function(...) list(open = 0, closed = 9),
     fetch_open_milestones = function(...) list(),
     fetch_branch_comparison = function(...) list(ahead_by = 0, behind_by = 0)
   )
@@ -107,6 +117,7 @@ test_that("summarize_github_repos shows grey badge when older version qualified"
   result <- with_mocked_bindings(
     summarize_github_repos("org/repo", qualification_registry = registry),
     fetch_latest_release = function(...) mock_release,
+    fetch_issue_counts = function(...) list(open = 2, closed = 5),
     fetch_open_milestones = function(...) list(),
     fetch_branch_comparison = function(...) list(ahead_by = 0, behind_by = 0)
   )
@@ -138,6 +149,10 @@ test_that("summarize_github_repos supports multiple repositories", {
     list(ahead_by = 0, behind_by = 0),
     list(ahead_by = 0, behind_by = 3)
   )
+  issue_counts <- list(
+    list(open = 1, closed = 4),
+    list(open = 0, closed = 0)
+  )
 
   index <- 0
   result <- with_mocked_bindings(
@@ -148,6 +163,9 @@ test_that("summarize_github_repos supports multiple repositories", {
     },
     fetch_open_milestones = function(owner, repo, token) {
       milestones[[index]]
+    },
+    fetch_issue_counts = function(owner, repo, token) {
+      issue_counts[[index]]
     },
     fetch_branch_comparison = function(owner, repo, base, head, token) {
       comparisons[[index]]
@@ -161,6 +179,8 @@ test_that("summarize_github_repos supports multiple repositories", {
   expect_match(result$latest_release[[1]], "2025-02-15")
   expect_match(result$latest_release[[2]], "<a href=\"https://github.com/org2/repo2/releases\">")
   expect_match(result$latest_release[[2]], "No release")
+  expect_match(result$open_vs_closed_issues[[1]], ">1 / 4<")
+  expect_match(result$open_vs_closed_issues[[2]], ">0 / 0<")
   expect_equal(
     result$dev_branch_status[[1]],
     "<a href=\"https://github.com/org/repo/compare/main...dev\">In sync</a>"


### PR DESCRIPTION
## Summary
- add GitHub issue count retrieval for open and closed issues (excluding PRs)
- add open_vs_closed_issues to summarize_github_repos output
- render a new Issues (open / closed) column in the dashboard table
- update tests for the new issue summary column

## Validation
- Rscript -e "devtools::test(filter='report-package-status')"