### PR TITLE
Add "Quality" Tab

### DIFF
--- a/R/github_api.R
+++ b/R/github_api.R
@@ -411,12 +411,6 @@ fetch_issue_counts <- function(owner, repo, token) {
   )
 }
 
-#' Check if error has specific HTTP status code
-#'
-#' Internal function to check if a GitHub API error has a specific status code.
-#'
-#' @param err Error object from GitHub API
-#' @param code HTTP status code to check for
 #' Fetch repository git tree from GitHub API
 #'
 #' Internal function to retrieve the full repository tree for a ref.

--- a/R/github_api.R
+++ b/R/github_api.R
@@ -93,7 +93,7 @@ fetch_open_prs <- function(owner, repo, token) {
     return(length(result))
   }
 
-  0
+  NULL
 }
 
 #' Fetch repository metadata from GitHub API

--- a/R/github_api.R
+++ b/R/github_api.R
@@ -417,6 +417,59 @@ fetch_issue_counts <- function(owner, repo, token) {
 #'
 #' @param err Error object from GitHub API
 #' @param code HTTP status code to check for
+#' Fetch repository git tree from GitHub API
+#'
+#' Internal function to retrieve the full repository tree for a ref.
+#'
+#' @param owner Repository owner (GitHub username or organization)
+#' @param repo Repository name
+#' @param ref Git ref (branch name, tag, or SHA)
+#' @param token GitHub personal access token (optional)
+#' @return List response from GitHub tree API, or NULL on failure
+#' @keywords internal
+#' @noRd
+fetch_repo_git_tree <- function(owner, repo, ref, token) {
+  safe_gh(
+    gh::gh,
+    "GET /repos/{owner}/{repo}/git/trees/{ref}",
+    owner = owner,
+    repo = repo,
+    ref = ref,
+    recursive = 1,
+    .token = token
+  )
+}
+
+#' Fetch file content from GitHub API
+#'
+#' Internal function to retrieve file contents for a specific path/ref.
+#'
+#' @param owner Repository owner (GitHub username or organization)
+#' @param repo Repository name
+#' @param path Repository-relative file path
+#' @param ref Git ref (branch name, tag, or SHA)
+#' @param token GitHub personal access token (optional)
+#' @return List response from GitHub contents API, or NULL on failure
+#' @keywords internal
+#' @noRd
+fetch_repo_file_content <- function(owner, repo, path, ref, token) {
+  safe_gh(
+    gh::gh,
+    "GET /repos/{owner}/{repo}/contents/{path}",
+    owner = owner,
+    repo = repo,
+    path = path,
+    ref = ref,
+    .token = token
+  )
+}
+
+#' Check if error has specific HTTP status code
+#'
+#' Internal function to check if a GitHub API error has a specific status code.
+#'
+#' @param err Error object from GitHub API
+#' @param code HTTP status code to check for
 #' @return Logical indicating if error has the specified status code
 #' @keywords internal
 has_status_code <- function(err, code) {

--- a/R/github_formatting.R
+++ b/R/github_formatting.R
@@ -356,6 +356,10 @@ format_issue_summary <- function(owner, repo, issues_snapshot, issues_90day) {
 format_pr_summary <- function(owner, repo, pr_count) {
   base_url <- sprintf("https://github.com/%s/%s/pulls", owner, repo)
 
+  if (is.null(pr_count)) {
+    return(as.character(htmltools::tags$a(href = base_url, "Unavailable")))
+  }
+
   if (pr_count == 0) {
     return(as.character(htmltools::tags$a(href = base_url, "None")))
   }

--- a/R/render_dash.R
+++ b/R/render_dash.R
@@ -9,10 +9,10 @@
 #' @param token GitHub personal access token (optional).
 #' @param qualification_registry_url URL or file path to the qualification registry CSV (optional).
 #' @param pr_activity_days Number of days to include in PR activity summaries (default: 365).
+#' @param clean Whether to clean intermediate files after rendering.
 #' @param include_quality Logical. When `TRUE` (the default), the Quality tab is
 #'   computed and rendered. Set to `FALSE` to skip the Quality tab and avoid the
 #'   additional GitHub API requests it requires.
-#' @param clean Whether to clean intermediate files after rendering.
 #'
 #' @return The path to the rendered HTML report (invisibly).
 #' @export
@@ -24,8 +24,8 @@ render_dash <- function(
   token = NULL,
   qualification_registry_url = NULL,
   pr_activity_days = 365,
-  include_quality = TRUE,
-  clean = TRUE
+  clean = TRUE,
+  include_quality = TRUE
 ) {
   if (!requireNamespace("rmarkdown", quietly = TRUE)) {
     stop("Package 'rmarkdown' is required to render the report.", call. = FALSE)

--- a/R/render_dash.R
+++ b/R/render_dash.R
@@ -9,6 +9,9 @@
 #' @param token GitHub personal access token (optional).
 #' @param qualification_registry_url URL or file path to the qualification registry CSV (optional).
 #' @param pr_activity_days Number of days to include in PR activity summaries (default: 365).
+#' @param include_quality Logical. When `TRUE` (the default), the Quality tab is
+#'   computed and rendered. Set to `FALSE` to skip the Quality tab and avoid the
+#'   additional GitHub API requests it requires.
 #' @param clean Whether to clean intermediate files after rendering.
 #'
 #' @return The path to the rendered HTML report (invisibly).
@@ -21,6 +24,7 @@ render_dash <- function(
   token = NULL,
   qualification_registry_url = NULL,
   pr_activity_days = 365,
+  include_quality = TRUE,
   clean = TRUE
 ) {
   if (!requireNamespace("rmarkdown", quietly = TRUE)) {
@@ -52,7 +56,8 @@ render_dash <- function(
       title = title,
       packageList = packages,
       qualification_registry_url = qualification_registry_url,
-      pr_activity_days = pr_activity_days
+      pr_activity_days = pr_activity_days,
+      include_quality = include_quality
     ),
     clean = clean
   )

--- a/R/summarize_repo_quality.R
+++ b/R/summarize_repo_quality.R
@@ -75,6 +75,17 @@ summarize_repo_quality <- function(repos, token = NULL) {
       next
     }
 
+    if (isTRUE(tree$truncated)) {
+      # Tree was truncated by GitHub (repo too large for a single recursive call);
+      # results would be incomplete so surface NA rather than misleading counts.
+      results[[idx]] <- list(
+        repo = format_repo_link(owner, repo, is_private = is_private),
+        test_count = NA_integer_,
+        qcthat_status = "Unavailable"
+      )
+      next
+    }
+
     tree_entries <- tree$tree
 
     if (is.null(tree_entries) || !length(tree_entries)) {

--- a/R/summarize_repo_quality.R
+++ b/R/summarize_repo_quality.R
@@ -1,71 +1,36 @@
-#' Fetch repository git tree from GitHub API
-#'
-#' Internal function to retrieve the full repository tree for a ref.
-#'
-#' @param owner Repository owner (GitHub username or organization)
-#' @param repo Repository name
-#' @param ref Git ref (branch name, tag, or SHA)
-#' @param token GitHub personal access token (optional)
-#' @return List response from GitHub tree API, or NULL on failure
-#' @keywords internal
-#' @importFrom gh gh
-fetch_repo_git_tree <- function(owner, repo, ref, token) {
-  safe_gh(
-    gh::gh,
-    "GET /repos/{owner}/{repo}/git/trees/{ref}",
-    owner = owner,
-    repo = repo,
-    ref = ref,
-    recursive = 1,
-    .token = token
-  )
-}
-
-#' Fetch file content from GitHub API
-#'
-#' Internal function to retrieve file contents for a specific path/ref.
-#'
-#' @param owner Repository owner (GitHub username or organization)
-#' @param repo Repository name
-#' @param path Repository-relative file path
-#' @param ref Git ref (branch name, tag, or SHA)
-#' @param token GitHub personal access token (optional)
-#' @return List response from GitHub contents API, or NULL on failure
-#' @keywords internal
-#' @importFrom gh gh
-fetch_repo_file_content <- function(owner, repo, path, ref, token) {
-  safe_gh(
-    gh::gh,
-    "GET /repos/{owner}/{repo}/contents/{path}",
-    owner = owner,
-    repo = repo,
-    path = path,
-    ref = ref,
-    .token = token
-  )
-}
-
 #' Count test_that calls in decoded R source
 #'
 #' @param source_text Character string with R code
-#' @return Integer number of `test_that(` occurrences
+#' @return Integer number of actual `test_that()` calls
 #' @keywords internal
+#' @noRd
 count_test_that_calls <- function(source_text) {
   if (is.null(source_text) || !length(source_text)) {
     return(0L)
   }
 
-  source_text <- as.character(source_text)
+  source_text <- paste(as.character(source_text), collapse = "\n")
   if (!nzchar(source_text)) {
     return(0L)
   }
 
-  matches <- gregexpr("test_that\\s*\\(", source_text, perl = TRUE)[[1]]
-  if (length(matches) == 1L && matches[[1]] == -1L) {
+  expr <- tryCatch(
+    parse(text = source_text, keep.source = TRUE),
+    error = function(e) NULL
+  )
+  if (is.null(expr)) {
     return(0L)
   }
 
-  as.integer(length(matches))
+  parse_data <- utils::getParseData(expr)
+  if (is.null(parse_data) || !nrow(parse_data)) {
+    return(0L)
+  }
+
+  as.integer(sum(
+    parse_data$token == "SYMBOL_FUNCTION_CALL" &
+      parse_data$text == "test_that"
+  ))
 }
 
 #' Summarize repository quality signals
@@ -77,6 +42,7 @@ count_test_that_calls <- function(source_text) {
 #' @param token Optional GitHub personal access token.
 #' @return Data frame with columns `repo`, `test_count`, and `qcthat_status`.
 #' @keywords internal
+#' @noRd
 summarize_repo_quality <- function(repos, token = NULL) {
   validate_repo_vector(repos)
 
@@ -93,6 +59,18 @@ summarize_repo_quality <- function(repos, token = NULL) {
     is_private <- metadata$private %||% FALSE
 
     tree <- fetch_repo_git_tree(owner, repo, default_branch, token)
+
+    if (is.null(tree)) {
+      # API failure (rate-limit or permission error) — surface NA rather than
+      # conflating unavailability with a genuinely empty repo.
+      results[[idx]] <- list(
+        repo = format_repo_link(owner, repo, is_private = is_private),
+        test_count = NA_integer_,
+        qcthat_status = "Unavailable"
+      )
+      next
+    }
+
     tree_entries <- tree$tree
 
     if (is.null(tree_entries) || !length(tree_entries)) {
@@ -110,6 +88,9 @@ summarize_repo_quality <- function(repos, token = NULL) {
       if (!length(test_file_paths)) {
         test_count <- 0L
       } else {
+        # Cap at 50 files to limit API usage and avoid rate-limit issues.
+        max_test_files <- 50L
+        test_file_paths <- utils::head(test_file_paths, max_test_files)
         test_total <- 0L
         for (path in test_file_paths) {
           content <- fetch_repo_file_content(owner, repo, path, default_branch, token)

--- a/R/summarize_repo_quality.R
+++ b/R/summarize_repo_quality.R
@@ -107,9 +107,11 @@ summarize_repo_quality <- function(repos, token = NULL) {
         max_test_files <- 50L
         test_file_paths <- utils::head(test_file_paths, max_test_files)
         test_total <- 0L
+        any_fetch_failed <- FALSE
         for (path in test_file_paths) {
           content <- fetch_repo_file_content(owner, repo, path, default_branch, token)
           if (is.null(content) || is.null(content$content) || !length(content$content)) {
+            any_fetch_failed <- TRUE
             next
           }
           encoded <- content$content
@@ -117,7 +119,8 @@ summarize_repo_quality <- function(repos, token = NULL) {
           decoded <- decode_base64_string(encoded)
           test_total <- test_total + count_test_that_calls(decoded)
         }
-        test_count <- as.integer(test_total)
+        # If any file could not be fetched, the count is incomplete; surface NA.
+        test_count <- if (any_fetch_failed) NA_integer_ else as.integer(test_total)
       }
     }
 

--- a/R/summarize_repo_quality.R
+++ b/R/summarize_repo_quality.R
@@ -55,8 +55,12 @@ summarize_repo_quality <- function(repos, token = NULL) {
     repo <- repo_parts$repo
 
     metadata <- fetch_repo_metadata(owner, repo, token)
-    default_branch <- metadata$default_branch %||% "HEAD"
-    is_private <- metadata$private %||% FALSE
+    default_branch <- "HEAD"
+    is_private <- FALSE
+    if (!is.null(metadata)) {
+      default_branch <- metadata$default_branch %||% "HEAD"
+      is_private <- metadata$private %||% FALSE
+    }
 
     tree <- fetch_repo_git_tree(owner, repo, default_branch, token)
 
@@ -94,10 +98,10 @@ summarize_repo_quality <- function(repos, token = NULL) {
         test_total <- 0L
         for (path in test_file_paths) {
           content <- fetch_repo_file_content(owner, repo, path, default_branch, token)
-          encoded <- content$content
-          if (is.null(encoded) || !length(encoded)) {
+          if (is.null(content) || is.null(content$content) || !length(content$content)) {
             next
           }
+          encoded <- content$content
 
           decoded <- decode_base64_string(encoded)
           test_total <- test_total + count_test_that_calls(decoded)

--- a/R/summarize_repo_quality.R
+++ b/R/summarize_repo_quality.R
@@ -1,0 +1,141 @@
+#' Fetch repository git tree from GitHub API
+#'
+#' Internal function to retrieve the full repository tree for a ref.
+#'
+#' @param owner Repository owner (GitHub username or organization)
+#' @param repo Repository name
+#' @param ref Git ref (branch name, tag, or SHA)
+#' @param token GitHub personal access token (optional)
+#' @return List response from GitHub tree API, or NULL on failure
+#' @keywords internal
+#' @importFrom gh gh
+fetch_repo_git_tree <- function(owner, repo, ref, token) {
+  safe_gh(
+    gh::gh,
+    "GET /repos/{owner}/{repo}/git/trees/{ref}",
+    owner = owner,
+    repo = repo,
+    ref = ref,
+    recursive = 1,
+    .token = token
+  )
+}
+
+#' Fetch file content from GitHub API
+#'
+#' Internal function to retrieve file contents for a specific path/ref.
+#'
+#' @param owner Repository owner (GitHub username or organization)
+#' @param repo Repository name
+#' @param path Repository-relative file path
+#' @param ref Git ref (branch name, tag, or SHA)
+#' @param token GitHub personal access token (optional)
+#' @return List response from GitHub contents API, or NULL on failure
+#' @keywords internal
+#' @importFrom gh gh
+fetch_repo_file_content <- function(owner, repo, path, ref, token) {
+  safe_gh(
+    gh::gh,
+    "GET /repos/{owner}/{repo}/contents/{path}",
+    owner = owner,
+    repo = repo,
+    path = path,
+    ref = ref,
+    .token = token
+  )
+}
+
+#' Count test_that calls in decoded R source
+#'
+#' @param source_text Character string with R code
+#' @return Integer number of `test_that(` occurrences
+#' @keywords internal
+count_test_that_calls <- function(source_text) {
+  if (is.null(source_text) || !length(source_text)) {
+    return(0L)
+  }
+
+  source_text <- as.character(source_text)
+  if (!nzchar(source_text)) {
+    return(0L)
+  }
+
+  matches <- gregexpr("test_that\\s*\\(", source_text, perl = TRUE)[[1]]
+  if (length(matches) == 1L && matches[[1]] == -1L) {
+    return(0L)
+  }
+
+  as.integer(length(matches))
+}
+
+#' Summarize repository quality signals
+#'
+#' Internal function that computes package-level quality indicators:
+#' the number of `test_that()` tests and whether qcthat workflow is present.
+#'
+#' @param repos Character vector of repositories in the form `owner/repo`.
+#' @param token Optional GitHub personal access token.
+#' @return Data frame with columns `repo`, `test_count`, and `qcthat_status`.
+#' @keywords internal
+summarize_repo_quality <- function(repos, token = NULL) {
+  validate_repo_vector(repos)
+
+  results <- vector("list", length(repos))
+
+  for (idx in seq_along(repos)) {
+    owner_repo <- repos[[idx]]
+    repo_parts <- split_repo_slug(owner_repo)
+    owner <- repo_parts$owner
+    repo <- repo_parts$repo
+
+    metadata <- fetch_repo_metadata(owner, repo, token)
+    default_branch <- metadata$default_branch %||% "HEAD"
+    is_private <- metadata$private %||% FALSE
+
+    tree <- fetch_repo_git_tree(owner, repo, default_branch, token)
+    tree_entries <- tree$tree
+
+    if (is.null(tree_entries) || !length(tree_entries)) {
+      test_count <- 0L
+      has_qcthat <- FALSE
+    } else {
+      tree_paths <- vapply(tree_entries, function(entry) entry$path %||% "", character(1))
+
+      has_qcthat <- any(tree_paths == ".github/workflows/qcthat.yaml")
+
+      test_file_paths <- tree_paths[
+        startsWith(tree_paths, "tests/testthat/") & grepl("\\.[Rr]$", tree_paths)
+      ]
+
+      if (!length(test_file_paths)) {
+        test_count <- 0L
+      } else {
+        test_total <- 0L
+        for (path in test_file_paths) {
+          content <- fetch_repo_file_content(owner, repo, path, default_branch, token)
+          encoded <- content$content
+          if (is.null(encoded) || !length(encoded)) {
+            next
+          }
+
+          decoded <- decode_base64_string(encoded)
+          test_total <- test_total + count_test_that_calls(decoded)
+        }
+        test_count <- as.integer(test_total)
+      }
+    }
+
+    results[[idx]] <- list(
+      repo = format_repo_link(owner, repo, is_private = is_private),
+      test_count = as.integer(test_count),
+      qcthat_status = if (isTRUE(has_qcthat)) "Yes" else "No"
+    )
+  }
+
+  data.frame(
+    repo = vapply(results, `[[`, character(1), "repo"),
+    test_count = vapply(results, `[[`, integer(1), "test_count"),
+    qcthat_status = vapply(results, `[[`, character(1), "qcthat_status"),
+    stringsAsFactors = FALSE
+  )
+}

--- a/inst/report/package_status_report.Rmd
+++ b/inst/report/package_status_report.Rmd
@@ -75,6 +75,20 @@ pr_activity <- if (length(repos) == 0L) {
     days = pr_activity_days
   )
 }
+
+quality <- if (length(repos) == 0L) {
+  data.frame(
+    repo = character(0),
+    test_count = integer(0),
+    qcthat_status = character(0),
+    stringsAsFactors = FALSE
+  )
+} else {
+  gh.dash:::summarize_repo_quality(
+    repos,
+    token = github_token
+  )
+}
 ```
 
 ```{r report_styles, echo = FALSE, results = 'asis'}
@@ -666,7 +680,53 @@ render_pr_activity_table <- function(df, days) {
   )
 }
 
-render_dashboard_tabs <- function(status_df, pr_activity_df, days) {
+render_quality_table <- function(df) {
+  if (!nrow(df)) {
+    return(htmltools::div(
+      class = "empty-state",
+      "No repositories available."
+    ))
+  }
+
+  rows <- lapply(seq_len(nrow(df)), function(i) {
+    htmltools::tags$tr(
+      htmltools::tags$td(
+        class = "status-table__cell status-table__cell--repo",
+        htmltools::HTML(df$repo[[i]])
+      ),
+      htmltools::tags$td(
+        class = "status-table__cell status-table__cell--right",
+        as.character(df$test_count[[i]])
+      ),
+      htmltools::tags$td(
+        class = "status-table__cell",
+        htmltools::htmlEscape(df$qcthat_status[[i]])
+      )
+    )
+  })
+
+  tbody <- htmltools::tagAppendChildren(htmltools::tags$tbody(), rows)
+
+  htmltools::div(
+    class = "status-table-wrapper",
+    htmltools::div(
+      class = "status-table-container",
+      htmltools::tags$table(
+        class = "status-table status-table--compact",
+        htmltools::tags$thead(
+          htmltools::tags$tr(
+            htmltools::tags$th(scope = "col", "Repository"),
+            htmltools::tags$th(scope = "col", class = "status-table__cell--right", "# of tests"),
+            htmltools::tags$th(scope = "col", "qcthat status")
+          )
+        ),
+        tbody
+      )
+    )
+  )
+}
+
+render_dashboard_tabs <- function(status_df, pr_activity_df, quality_df, days) {
   htmltools::browsable(
     htmltools::div(
       class = "dash-tabs",
@@ -683,6 +743,12 @@ render_dashboard_tabs <- function(status_df, pr_activity_df, days) {
           type = "button",
           `data-tab-target` = "tab-pr-activity",
           sprintf("PR Activity (Last %d Days)", days)
+        ),
+        htmltools::tags$button(
+          class = "dash-tabs__button",
+          type = "button",
+          `data-tab-target` = "tab-quality",
+          "Quality"
         )
       ),
       htmltools::div(
@@ -694,12 +760,17 @@ render_dashboard_tabs <- function(status_df, pr_activity_df, days) {
         id = "tab-pr-activity",
         class = "dash-tab-panel",
         render_pr_activity_table(pr_activity_df, days)
+      ),
+      htmltools::div(
+        id = "tab-quality",
+        class = "dash-tab-panel",
+        render_quality_table(quality_df)
       )
     )
   )
 }
 
-render_dashboard_tabs(status, pr_activity, pr_activity_days)
+render_dashboard_tabs(status, pr_activity, quality, pr_activity_days)
 ```
 
 ```{r column_settings_js, echo=FALSE, results='asis'}

--- a/inst/report/package_status_report.Rmd
+++ b/inst/report/package_status_report.Rmd
@@ -717,7 +717,7 @@ render_quality_table <- function(df) {
           htmltools::tags$tr(
             htmltools::tags$th(scope = "col", "Repository"),
             htmltools::tags$th(scope = "col", class = "status-table__cell--right", "# of tests"),
-            htmltools::tags$th(scope = "col", "qcthat status")
+            htmltools::tags$th(scope = "col", "uses qcthat")
           )
         ),
         tbody

--- a/inst/report/package_status_report.Rmd
+++ b/inst/report/package_status_report.Rmd
@@ -697,7 +697,7 @@ render_quality_table <- function(df) {
       ),
       htmltools::tags$td(
         class = "status-table__cell status-table__cell--right",
-        as.character(df$test_count[[i]])
+        if (is.na(df$test_count[[i]])) "\u2014" else as.character(df$test_count[[i]])
       ),
       htmltools::tags$td(
         class = "status-table__cell",

--- a/inst/report/package_status_report.Rmd
+++ b/inst/report/package_status_report.Rmd
@@ -10,6 +10,7 @@ params:
   repo: "gh.dash"
   qualification_registry_url: NULL
   pr_activity_days: 365
+  include_quality: TRUE
 ---
 
 This report summarizes the current release and milestone status for a selection of `r params$title` packages hosted on GitHub.
@@ -76,7 +77,7 @@ pr_activity <- if (length(repos) == 0L) {
   )
 }
 
-quality <- if (length(repos) == 0L) {
+quality <- if (!isTRUE(params$include_quality) || length(repos) == 0L) {
   data.frame(
     repo = character(0),
     test_count = integer(0),
@@ -726,51 +727,68 @@ render_quality_table <- function(df) {
   )
 }
 
-render_dashboard_tabs <- function(status_df, pr_activity_df, quality_df, days) {
+render_dashboard_tabs <- function(status_df, pr_activity_df, quality_df, days, include_quality) {
+  tab_buttons <- list(
+    htmltools::tags$button(
+      class = "dash-tabs__button is-active",
+      type = "button",
+      `data-tab-target` = "tab-repo-status",
+      "Repository Status"
+    ),
+    htmltools::tags$button(
+      class = "dash-tabs__button",
+      type = "button",
+      `data-tab-target` = "tab-pr-activity",
+      sprintf("PR Activity (Last %d Days)", days)
+    )
+  )
+
+  tab_panels <- list(
+    htmltools::div(
+      id = "tab-repo-status",
+      class = "dash-tab-panel is-active",
+      render_status_table(status_df)
+    ),
+    htmltools::div(
+      id = "tab-pr-activity",
+      class = "dash-tab-panel",
+      render_pr_activity_table(pr_activity_df, days)
+    )
+  )
+
+  if (isTRUE(include_quality)) {
+    tab_buttons <- c(
+      tab_buttons,
+      list(htmltools::tags$button(
+        class = "dash-tabs__button",
+        type = "button",
+        `data-tab-target` = "tab-quality",
+        "Quality"
+      ))
+    )
+    tab_panels <- c(
+      tab_panels,
+      list(htmltools::div(
+        id = "tab-quality",
+        class = "dash-tab-panel",
+        render_quality_table(quality_df)
+      ))
+    )
+  }
+
   htmltools::browsable(
     htmltools::div(
       class = "dash-tabs",
       htmltools::div(
         class = "dash-tabs__list",
-        htmltools::tags$button(
-          class = "dash-tabs__button is-active",
-          type = "button",
-          `data-tab-target` = "tab-repo-status",
-          "Repository Status"
-        ),
-        htmltools::tags$button(
-          class = "dash-tabs__button",
-          type = "button",
-          `data-tab-target` = "tab-pr-activity",
-          sprintf("PR Activity (Last %d Days)", days)
-        ),
-        htmltools::tags$button(
-          class = "dash-tabs__button",
-          type = "button",
-          `data-tab-target` = "tab-quality",
-          "Quality"
-        )
+        tab_buttons
       ),
-      htmltools::div(
-        id = "tab-repo-status",
-        class = "dash-tab-panel is-active",
-        render_status_table(status_df)
-      ),
-      htmltools::div(
-        id = "tab-pr-activity",
-        class = "dash-tab-panel",
-        render_pr_activity_table(pr_activity_df, days)
-      ),
-      htmltools::div(
-        id = "tab-quality",
-        class = "dash-tab-panel",
-        render_quality_table(quality_df)
-      )
+      tab_panels
     )
   )
 }
 
-render_dashboard_tabs(status, pr_activity, quality, pr_activity_days)
+render_dashboard_tabs(status, pr_activity, quality, pr_activity_days, params$include_quality)
 ```
 
 ```{r column_settings_js, echo=FALSE, results='asis'}

--- a/man/render_dash.Rd
+++ b/man/render_dash.Rd
@@ -12,8 +12,8 @@ render_dash(
   token = NULL,
   qualification_registry_url = NULL,
   pr_activity_days = 365,
-  include_quality = TRUE,
-  clean = TRUE
+  clean = TRUE,
+  include_quality = TRUE
 )
 }
 \arguments{
@@ -31,11 +31,11 @@ render_dash(
 
 \item{pr_activity_days}{Number of days to include in PR activity summaries (default: 365).}
 
+\item{clean}{Whether to clean intermediate files after rendering.}
+
 \item{include_quality}{Logical. When \code{TRUE} (the default), the Quality tab is
 computed and rendered. Set to \code{FALSE} to skip the Quality tab and avoid the
 additional GitHub API requests it requires.}
-
-\item{clean}{Whether to clean intermediate files after rendering.}
 }
 \value{
 The path to the rendered HTML report (invisibly).

--- a/man/render_dash.Rd
+++ b/man/render_dash.Rd
@@ -12,6 +12,7 @@ render_dash(
   token = NULL,
   qualification_registry_url = NULL,
   pr_activity_days = 365,
+  include_quality = TRUE,
   clean = TRUE
 )
 }
@@ -29,6 +30,10 @@ render_dash(
 \item{qualification_registry_url}{URL or file path to the qualification registry CSV (optional).}
 
 \item{pr_activity_days}{Number of days to include in PR activity summaries (default: 365).}
+
+\item{include_quality}{Logical. When \code{TRUE} (the default), the Quality tab is
+computed and rendered. Set to \code{FALSE} to skip the Quality tab and avoid the
+additional GitHub API requests it requires.}
 
 \item{clean}{Whether to clean intermediate files after rendering.}
 }

--- a/tests/testthat/test-report-package-status.R
+++ b/tests/testthat/test-report-package-status.R
@@ -143,6 +143,20 @@ test_that("summarize_github_repos includes open PR count", {
   expect_equal(result$open_prs, "<a href=\"https://github.com/org/repo/pulls\">3</a>")
 })
 
+test_that("summarize_github_repos shows Unavailable when fetch_open_prs returns NULL", {
+  result <- with_mocked_bindings(
+    summarize_github_repos("org/repo"),
+    fetch_repo_metadata = function(...) list(private = FALSE),
+    fetch_releases = function(...) list(),
+    fetch_open_milestones = function(...) list(),
+    fetch_open_prs = function(...) NULL,
+    fetch_issue_counts = function(...) list(issues_snapshot = list(open = 0L, closed = 0L), issues_90day = list(opened = 0L, closed = 0L)),
+    fetch_branch_comparison = function(...) list(ahead_by = 0, behind_by = 0)
+  )
+
+  expect_equal(result$open_prs, "<a href=\"https://github.com/org/repo/pulls\">Unavailable</a>")
+})
+
 test_that("summarize_github_repos appends qualification badge when registry matches", {
   mock_release <- list(
     tag_name = "v1.0.0",

--- a/tests/testthat/test-summarize-repo-quality.R
+++ b/tests/testthat/test-summarize-repo-quality.R
@@ -55,3 +55,40 @@ test_that("summarize_repo_quality handles missing tree data", {
   expect_equal(result$test_count, NA_integer_)
   expect_equal(result$qcthat_status, "Unavailable")
 })
+
+test_that("summarize_repo_quality handles truncated tree", {
+  result <- with_mocked_bindings(
+    gh.dash:::summarize_repo_quality("org/repo"),
+    .package = "gh.dash",
+    fetch_repo_metadata = function(...) list(private = FALSE, default_branch = "main"),
+    fetch_repo_git_tree = function(...) list(truncated = TRUE, tree = list()),
+    fetch_repo_file_content = function(...) stop("should not be called")
+  )
+
+  expect_equal(result$test_count, NA_integer_)
+  expect_equal(result$qcthat_status, "Unavailable")
+})
+
+test_that("summarize_repo_quality returns NA test_count when a file fetch fails", {
+  result <- with_mocked_bindings(
+    gh.dash:::summarize_repo_quality("org/repo"),
+    .package = "gh.dash",
+    fetch_repo_metadata = function(...) list(private = FALSE, default_branch = "main"),
+    fetch_repo_git_tree = function(...) list(
+      tree = list(
+        list(path = "tests/testthat/test-one.R"),
+        list(path = "tests/testthat/test-two.R")
+      )
+    ),
+    fetch_repo_file_content = function(owner, repo, path, ref, token) {
+      if (path == "tests/testthat/test-one.R") {
+        list(content = base64enc::base64encode(charToRaw("test_that('a', {})\n")))
+      } else {
+        NULL  # simulate API failure for second file
+      }
+    }
+  )
+
+  expect_equal(result$test_count, NA_integer_)
+  expect_equal(result$qcthat_status, "No")
+})

--- a/tests/testthat/test-summarize-repo-quality.R
+++ b/tests/testthat/test-summarize-repo-quality.R
@@ -52,6 +52,6 @@ test_that("summarize_repo_quality handles missing tree data", {
     fetch_repo_file_content = function(...) stop("should not be called")
   )
 
-  expect_equal(result$test_count, 0L)
-  expect_equal(result$qcthat_status, "No")
+  expect_equal(result$test_count, NA_integer_)
+  expect_equal(result$qcthat_status, "Unavailable")
 })

--- a/tests/testthat/test-summarize-repo-quality.R
+++ b/tests/testthat/test-summarize-repo-quality.R
@@ -1,0 +1,57 @@
+test_that("count_test_that_calls counts test_that invocations", {
+  expect_equal(gh.dash:::count_test_that_calls(NULL), 0L)
+  expect_equal(gh.dash:::count_test_that_calls(""), 0L)
+  expect_equal(
+    gh.dash:::count_test_that_calls("test_that('a', {});\n test_that ('b', {})"),
+    2L
+  )
+})
+
+test_that("summarize_repo_quality validates repository format", {
+  expect_error(gh.dash:::summarize_repo_quality(42), "character vector")
+  expect_error(gh.dash:::summarize_repo_quality(character(0)), "at least one")
+  expect_error(gh.dash:::summarize_repo_quality(c("")), "cannot contain empty strings")
+  expect_error(gh.dash:::summarize_repo_quality(c("invalid")), "owner/repo")
+})
+
+test_that("summarize_repo_quality reports test count and qcthat status", {
+  result <- with_mocked_bindings(
+    gh.dash:::summarize_repo_quality("org/repo"),
+    .package = "gh.dash",
+    fetch_repo_metadata = function(...) list(private = FALSE, default_branch = "main"),
+    fetch_repo_git_tree = function(...) list(
+      tree = list(
+        list(path = "tests/testthat/test-one.R"),
+        list(path = "tests/testthat/test-two.R"),
+        list(path = ".github/workflows/qcthat.yaml")
+      )
+    ),
+    fetch_repo_file_content = function(owner, repo, path, ref, token) {
+      content <- switch(
+        path,
+        "tests/testthat/test-one.R" = "test_that('a', {})\n",
+        "tests/testthat/test-two.R" = "test_that('b', {})\n test_that('c', {})\n",
+        ""
+      )
+      list(content = base64enc::base64encode(charToRaw(content)))
+    }
+  )
+
+  expect_s3_class(result, "data.frame")
+  expect_equal(result$repo, "<a href=\"https://github.com/org/repo\">org/repo</a>")
+  expect_equal(result$test_count, 3L)
+  expect_equal(result$qcthat_status, "Yes")
+})
+
+test_that("summarize_repo_quality handles missing tree data", {
+  result <- with_mocked_bindings(
+    gh.dash:::summarize_repo_quality("org/repo"),
+    .package = "gh.dash",
+    fetch_repo_metadata = function(...) list(private = FALSE, default_branch = "main"),
+    fetch_repo_git_tree = function(...) NULL,
+    fetch_repo_file_content = function(...) stop("should not be called")
+  )
+
+  expect_equal(result$test_count, 0L)
+  expect_equal(result$qcthat_status, "No")
+})


### PR DESCRIPTION
- Closes #7 

Adds a new “Quality” tab to the package status dashboard by computing per-repo quality signals (testthat `test_that()` count and presence of a `qcthat` workflow) via the GitHub API.

Changes:
- Introduces `summarize_repo_quality()` plus helpers to scan a repo’s git tree and count `test_that(` occurrences in `tests/testthat/*.R`.
- Extends the report `Rmd` to compute and render a new “Quality” tab/table.
- Adds unit tests covering repo validation, `test_that` counting, and basic quality summarization behavior.
