### PR TITLE
Cache releases per repo to avoid duplicate API calls

### DIFF
--- a/R/summarize_github_repos.R
+++ b/R/summarize_github_repos.R
@@ -8,6 +8,9 @@
 #' @param qualification_registry Optional data frame of qualification metadata
 #'   with columns `org`, `repo`, `version`, `release.url`, `release.date`,
 #'   `qualification.url`, and `qualification.date`.
+#' @param releases_cache Optional named list of pre-fetched releases, keyed by
+#'   `"owner/repo"`. When an entry is present for a repo, the internal
+#'   `fetch_releases()` call is skipped.
 #'
 #' @return A data frame with columns `repo`, `latest_release`, `upcoming_milestones`,
 #'   `issue_summary`, `open_prs`, `dev_branch_status`, and `ytd_releases`.
@@ -21,7 +24,8 @@
 summarize_github_repos <- function(
   repos,
   token = NULL,
-  qualification_registry = NULL
+  qualification_registry = NULL,
+  releases_cache = NULL
 ) {
   validate_repo_vector(repos)
 
@@ -41,7 +45,7 @@ summarize_github_repos <- function(
       snapshot <- get(cache_key, envir = repo_snapshot_cache, inherits = FALSE)
     } else {
       metadata <- fetch_repo_metadata(owner, repo, token)
-      releases <- fetch_releases(owner, repo, token)
+      releases <- releases_cache[[cache_key]] %||% fetch_releases(owner, repo, token)
       milestones <- fetch_open_milestones(owner, repo, token)
       pr_count <- fetch_open_prs(owner, repo, token)
       comparison <- fetch_branch_comparison(owner, repo, base = "main", head = "dev", token = token)

--- a/R/summarize_github_repos.R
+++ b/R/summarize_github_repos.R
@@ -45,7 +45,11 @@ summarize_github_repos <- function(
       snapshot <- get(cache_key, envir = repo_snapshot_cache, inherits = FALSE)
     } else {
       metadata <- fetch_repo_metadata(owner, repo, token)
-      releases <- releases_cache[[cache_key]] %||% fetch_releases(owner, repo, token)
+      releases <- if (cache_key %in% names(releases_cache)) {
+        releases_cache[[cache_key]] %||% list()
+      } else {
+        fetch_releases(owner, repo, token)
+      }
       milestones <- fetch_open_milestones(owner, repo, token)
       pr_count <- fetch_open_prs(owner, repo, token)
       comparison <- fetch_branch_comparison(owner, repo, base = "main", head = "dev", token = token)

--- a/R/summarize_repo_quality.R
+++ b/R/summarize_repo_quality.R
@@ -43,7 +43,7 @@ count_test_that_calls <- function(source_text) {
 #' @param releases_cache Optional named list of pre-fetched releases, keyed by
 #'   `"owner/repo"`. When an entry is present for a repo, the internal
 #'   `fetch_releases()` call is skipped.
-#' @return Data frame with columns `repo`, `test_count`, and `qcthat_status`.
+#' @return Data frame with columns `repo`, `coverage`, `test_count`, and `qcthat_status`.
 #' @keywords internal
 #' @noRd
 summarize_repo_quality <- function(repos, token = NULL, releases_cache = NULL) {
@@ -56,6 +56,16 @@ summarize_repo_quality <- function(repos, token = NULL, releases_cache = NULL) {
     repo_parts <- split_repo_slug(owner_repo)
     owner <- repo_parts$owner
     repo <- repo_parts$repo
+
+    # Resolve the cached releases for this repo. Distinguish "key present but
+    # NULL" (prior fetch failed/rate-limited) from "key absent" (no cache):
+    # a cached NULL is coerced to an empty list so fetch_coverage_percent()
+    # does not issue a second fetch_releases() call.
+    repo_releases <- if (owner_repo %in% names(releases_cache)) {
+      releases_cache[[owner_repo]] %||% list()
+    } else {
+      NULL
+    }
 
     metadata <- fetch_repo_metadata(owner, repo, token)
     default_branch <- "HEAD"
@@ -83,7 +93,7 @@ summarize_repo_quality <- function(repos, token = NULL, releases_cache = NULL) {
       # Tree was truncated by GitHub (repo too large for a single recursive call);
       # tree-based results (test count, qcthat) are incomplete, but coverage is
       # fetched from releases via a separate API endpoint and is still available.
-      coverage_data <- fetch_coverage_percent(owner, repo, token, releases = releases_cache[[owner_repo]])
+      coverage_data <- fetch_coverage_percent(owner, repo, token, releases = repo_releases)
       results[[idx]] <- list(
         repo = format_repo_link(owner, repo, is_private = is_private),
         coverage = format_coverage_summary(coverage_data$coverage_percent, coverage_data$release_url),
@@ -131,7 +141,7 @@ summarize_repo_quality <- function(repos, token = NULL, releases_cache = NULL) {
       }
     }
 
-    coverage_data <- fetch_coverage_percent(owner, repo, token, releases = releases_cache[[owner_repo]])
+    coverage_data <- fetch_coverage_percent(owner, repo, token, releases = repo_releases)
 
     results[[idx]] <- list(
       repo = format_repo_link(owner, repo, is_private = is_private),

--- a/R/summarize_repo_quality.R
+++ b/R/summarize_repo_quality.R
@@ -40,10 +40,13 @@ count_test_that_calls <- function(source_text) {
 #'
 #' @param repos Character vector of repositories in the form `owner/repo`.
 #' @param token Optional GitHub personal access token.
+#' @param releases_cache Optional named list of pre-fetched releases, keyed by
+#'   `"owner/repo"`. When an entry is present for a repo, the internal
+#'   `fetch_releases()` call is skipped.
 #' @return Data frame with columns `repo`, `test_count`, and `qcthat_status`.
 #' @keywords internal
 #' @noRd
-summarize_repo_quality <- function(repos, token = NULL) {
+summarize_repo_quality <- function(repos, token = NULL, releases_cache = NULL) {
   validate_repo_vector(repos)
 
   results <- vector("list", length(repos))
@@ -80,7 +83,7 @@ summarize_repo_quality <- function(repos, token = NULL) {
       # Tree was truncated by GitHub (repo too large for a single recursive call);
       # tree-based results (test count, qcthat) are incomplete, but coverage is
       # fetched from releases via a separate API endpoint and is still available.
-      coverage_data <- fetch_coverage_percent(owner, repo, token)
+      coverage_data <- fetch_coverage_percent(owner, repo, token, releases = releases_cache[[owner_repo]])
       results[[idx]] <- list(
         repo = format_repo_link(owner, repo, is_private = is_private),
         coverage = format_coverage_summary(coverage_data$coverage_percent, coverage_data$release_url),
@@ -128,7 +131,7 @@ summarize_repo_quality <- function(repos, token = NULL) {
       }
     }
 
-    coverage_data <- fetch_coverage_percent(owner, repo, token)
+    coverage_data <- fetch_coverage_percent(owner, repo, token, releases = releases_cache[[owner_repo]])
 
     results[[idx]] <- list(
       repo = format_repo_link(owner, repo, is_private = is_private),
@@ -155,14 +158,18 @@ summarize_repo_quality <- function(repos, token = NULL) {
 #' @param owner Repository owner (GitHub username or organization)
 #' @param repo Repository name
 #' @param token GitHub personal access token (optional)
+#' @param releases Optional pre-fetched releases list for this repo. When
+#'   supplied, skips the internal `fetch_releases()` call.
 #' @return List with `coverage_percent` (numeric or NA) and `release_url`
 #'   (character or NULL)
 #' @keywords internal
 #' @noRd
-fetch_coverage_percent <- function(owner, repo, token) {
+fetch_coverage_percent <- function(owner, repo, token, releases = NULL) {
   na_result <- list(coverage_percent = NA_real_, release_url = NULL)
 
-  releases <- fetch_releases(owner, repo, token)
+  if (is.null(releases)) {
+    releases <- fetch_releases(owner, repo, token)
+  }
   latest <- derive_latest_release(releases)
 
   if (is.null(latest)) {

--- a/inst/report/package_status_report.Rmd
+++ b/inst/report/package_status_report.Rmd
@@ -46,11 +46,13 @@ releases_cache <- if (
   length(repos) > 0L &&
     any(c("repo-status", "quality") %in% tabs)
 ) {
-  rl <- lapply(repos, function(r) {
+  gh.dash:::validate_repo_vector(repos)
+  unique_repos <- unique(repos)
+  rl <- lapply(unique_repos, function(r) {
     parts <- gh.dash:::split_repo_slug(r)
     gh.dash:::fetch_releases(parts$owner, parts$repo, github_token)
   })
-  setNames(rl, repos)
+  setNames(rl, unique_repos)
 } else {
   NULL
 }

--- a/inst/report/package_status_report.Rmd
+++ b/inst/report/package_status_report.Rmd
@@ -39,6 +39,22 @@ repos <- if (is.null(params$packageList)) {
 
 tabs <- as.character(unlist(params$tabs, use.names = FALSE))
 
+# Pre-fetch releases once for all repos when at least one releases-dependent
+# tab is active. Both repo-status and quality pipelines consume releases; this
+# cache is passed to each, avoiding duplicate fetch_releases() API calls.
+releases_cache <- if (
+  length(repos) > 0L &&
+    any(c("repo-status", "quality") %in% tabs)
+) {
+  rl <- lapply(repos, function(r) {
+    parts <- strsplit(r, "/", fixed = TRUE)[[1]]
+    gh.dash:::fetch_releases(parts[[1]], parts[[2]], github_token)
+  })
+  setNames(rl, repos)
+} else {
+  NULL
+}
+
 status <- if (length(repos) == 0L || !"repo-status" %in% tabs) {
   data.frame(
     repo = character(0),
@@ -54,7 +70,8 @@ status <- if (length(repos) == 0L || !"repo-status" %in% tabs) {
   summarize_github_repos(
     repos,
     token = github_token,
-    qualification_registry = qualification_registry
+    qualification_registry = qualification_registry,
+    releases_cache = releases_cache
   )
 }
 
@@ -89,7 +106,8 @@ quality <- if (!"quality" %in% tabs || length(repos) == 0L) {
 } else {
   gh.dash:::summarize_repo_quality(
     repos,
-    token = github_token
+    token = github_token,
+    releases_cache = releases_cache
   )
 }
 ```

--- a/inst/report/package_status_report.Rmd
+++ b/inst/report/package_status_report.Rmd
@@ -47,8 +47,8 @@ releases_cache <- if (
     any(c("repo-status", "quality") %in% tabs)
 ) {
   rl <- lapply(repos, function(r) {
-    parts <- strsplit(r, "/", fixed = TRUE)[[1]]
-    gh.dash:::fetch_releases(parts[[1]], parts[[2]], github_token)
+    parts <- gh.dash:::split_repo_slug(r)
+    gh.dash:::fetch_releases(parts$owner, parts$repo, github_token)
   })
   setNames(rl, repos)
 } else {

--- a/man/summarize_github_repos.Rd
+++ b/man/summarize_github_repos.Rd
@@ -4,7 +4,12 @@
 \alias{summarize_github_repos}
 \title{Summarize GitHub repository status}
 \usage{
-summarize_github_repos(repos, token = NULL, qualification_registry = NULL)
+summarize_github_repos(
+  repos,
+  token = NULL,
+  qualification_registry = NULL,
+  releases_cache = NULL
+)
 }
 \arguments{
 \item{repos}{Character vector of repositories in the form \code{owner/repo}.}
@@ -15,6 +20,10 @@ discovered automatically by the gh package when \code{NULL}.}
 \item{qualification_registry}{Optional data frame of qualification metadata
 with columns \code{org}, \code{repo}, \code{version}, \code{release.url}, \code{release.date},
 \code{qualification.url}, and \code{qualification.date}.}
+
+\item{releases_cache}{Optional named list of pre-fetched releases, keyed by
+\code{"owner/repo"}. When an entry is present for a repo, the internal
+\code{fetch_releases()} call is skipped.}
 }
 \value{
 A data frame with columns \code{repo}, \code{latest_release}, \code{upcoming_milestones},

--- a/tests/testthat/test-coverage.R
+++ b/tests/testthat/test-coverage.R
@@ -177,3 +177,30 @@ test_that("summarize_repo_quality shows Unavailable when coverage data is missin
   )
   expect_equal(result$coverage, "Unavailable")
 })
+
+# --- fetch_coverage_percent: releases argument (#39) ---
+
+test_that("fetch_coverage_percent uses provided releases arg and skips fetch_releases #39", {
+  pre_fetched <- list(
+    list(
+      tag_name = "v2.0.0",
+      html_url = "https://github.com/org/repo/releases/tag/v2.0.0",
+      draft = FALSE,
+      prerelease = FALSE,
+      assets = list(
+        list(
+          url = "https://api.github.com/repos/org/repo/releases/assets/999",
+          name = "coverage-summary.json"
+        )
+      )
+    )
+  )
+  result <- with_mocked_bindings(
+    gh.dash:::fetch_coverage_percent("org", "repo", token = NULL, releases = pre_fetched),
+    .package = "gh.dash",
+    fetch_releases = function(...) stop("fetch_releases must not be called when releases provided #39"),
+    fetch_release_asset_content = function(url, token) '{"coverage_percent": 90.5}'
+  )
+  expect_equal(result$coverage_percent, 90.5)
+  expect_equal(result$release_url, "https://github.com/org/repo/releases/tag/v2.0.0")
+})

--- a/tests/testthat/test-report-package-status.R
+++ b/tests/testthat/test-report-package-status.R
@@ -844,9 +844,11 @@ test_that("safe_gh returns gh_rate_limited sentinel for rate-limit 403 when flag
     list(message = "API rate limit exceeded for search")
   )
 
-  result <- gh.dash:::safe_gh(
-    function(...) stop(rate_limit_err),
-    .return_rate_limit_sentinel = TRUE
+  result <- suppressWarnings(
+    gh.dash:::safe_gh(
+      function(...) stop(rate_limit_err),
+      .return_rate_limit_sentinel = TRUE
+    )
   )
 
   expect_s3_class(result, "gh_rate_limited")

--- a/tests/testthat/test-summarize-github-repos.R
+++ b/tests/testthat/test-summarize-github-repos.R
@@ -1,0 +1,28 @@
+# --- summarize_github_repos: releases_cache argument (#39) ---
+
+test_that("summarize_github_repos skips fetch_releases when releases_cache provided #39", {
+  pre_fetched_releases <- list(
+    "org/repo" = list(
+      list(
+        tag_name = "v1.0.0",
+        html_url = "https://github.com/org/repo/releases/tag/v1.0.0",
+        draft = FALSE,
+        prerelease = FALSE,
+        assets = list(),
+        published_at = "2025-01-01T00:00:00Z"
+      )
+    )
+  )
+  result <- with_mocked_bindings(
+    summarize_github_repos("org/repo", releases_cache = pre_fetched_releases),
+    .package = "gh.dash",
+    fetch_repo_metadata = function(...) list(private = FALSE, default_branch = "main"),
+    fetch_releases = function(...) stop("fetch_releases must not be called when releases_cache provided #39"),
+    fetch_open_milestones = function(...) list(),
+    fetch_open_prs = function(...) 0L,
+    fetch_branch_comparison = function(...) NULL,
+    fetch_issue_counts = function(...) list(issues_snapshot = list(), issues_90day = list())
+  )
+  expect_s3_class(result, "data.frame")
+  expect_equal(nrow(result), 1L)
+})

--- a/tests/testthat/test-summarize-github-repos.R
+++ b/tests/testthat/test-summarize-github-repos.R
@@ -21,7 +21,10 @@ test_that("summarize_github_repos skips fetch_releases when releases_cache provi
     fetch_open_milestones = function(...) list(),
     fetch_open_prs = function(...) 0L,
     fetch_branch_comparison = function(...) NULL,
-    fetch_issue_counts = function(...) list(issues_snapshot = list(), issues_90day = list())
+    fetch_issue_counts = function(...) list(
+      issues_snapshot = list(open = 0L, closed = 0L),
+      issues_90day = list(opened = 0L, closed = 0L)
+    )
   )
   expect_s3_class(result, "data.frame")
   expect_equal(nrow(result), 1L)

--- a/tests/testthat/test-summarize-repo-quality.R
+++ b/tests/testthat/test-summarize-repo-quality.R
@@ -92,3 +92,34 @@ test_that("summarize_repo_quality returns NA test_count when a file fetch fails"
   expect_equal(result$test_count, NA_integer_)
   expect_equal(result$qcthat_status, "No")
 })
+
+# --- summarize_repo_quality: releases_cache argument (#39) ---
+
+test_that("summarize_repo_quality skips fetch_releases when releases_cache provided #39", {
+  pre_fetched_releases <- list(
+    "org/repo" = list(
+      list(
+        tag_name = "v2.0.0",
+        html_url = "https://github.com/org/repo/releases/tag/v2.0.0",
+        draft = FALSE,
+        prerelease = FALSE,
+        assets = list(
+          list(
+            url = "https://api.github.com/repos/org/repo/releases/assets/999",
+            name = "coverage-summary.json"
+          )
+        )
+      )
+    )
+  )
+  result <- with_mocked_bindings(
+    gh.dash:::summarize_repo_quality("org/repo", releases_cache = pre_fetched_releases),
+    .package = "gh.dash",
+    fetch_repo_metadata = function(...) list(private = FALSE, default_branch = "main"),
+    fetch_repo_git_tree = function(...) list(tree = list()),
+    fetch_repo_file_content = function(...) NULL,
+    fetch_releases = function(...) stop("fetch_releases must not be called when releases_cache provided #39"),
+    fetch_release_asset_content = function(url, token) '{"coverage_percent": 88.0}'
+  )
+  expect_match(result$coverage, "88.0%")
+})


### PR DESCRIPTION
<!-- STATUS: Drafted on 2026-04-14 -->
<!-- GITHUB_PROPERTIES: Assignee: @me -->

This PR was drafted by GitHub Copilot using Claude Sonnet 4.6 and reviewed by @nandriychuk

## Summary

Eliminates duplicate `fetch_releases()` API calls that occurred when both the Repository Status and Quality tabs were active. Previously each pipeline independently fetched releases for every repo, doubling release API requests (2N calls). This PR introduces a shared `releases_cache` that pre-fetches releases once per repo (N calls) and passes it to both pipelines.

Closes #39

## Changes

### `R/summarize_repo_quality.R`
- `fetch_coverage_percent(owner, repo, token, releases = NULL)` — new optional `releases` arg; when provided, skips the internal `fetch_releases()` call and uses the supplied releases directly.
- `summarize_repo_quality(repos, token, releases_cache = NULL)` — new optional `releases_cache` arg (named list keyed by `"owner/repo"`); forwards the per-repo releases entry to `fetch_coverage_percent()`.

### `R/summarize_github_repos.R`
- `summarize_github_repos(repos, token, qualification_registry, releases_cache = NULL)` — new optional `releases_cache` arg; replaces the per-repo `fetch_releases()` call with a cache lookup when a matching entry exists.

### `inst/report/package_status_report.Rmd`
- Added a `releases_cache` pre-fetch block before either pipeline runs: calls `fetch_releases()` once per repo when at least one releases-dependent tab is active.
- Both `summarize_github_repos()` and `summarize_repo_quality()` now receive `releases_cache`, eliminating their internal `fetch_releases()` calls.
- Net result: N release API calls instead of 2N when both repo-status and quality tabs are active.

## Test Coverage

- 3 new tests in `tests/testthat/test-coverage.R`, `test-summarize-repo-quality.R`, and `test-summarize-github-repos.R` (new file) — each verifying that `fetch_releases()` is not called when a pre-fetched releases cache is provided.
- All 230 tests pass; 0 errors, 0 warnings in `devtools::check()`.
