### PR TITLE
feat: support cm-operations-bot App token in render-report-reusable.yaml

### DIFF
--- a/.github/workflows/render-report-reusable.yaml
+++ b/.github/workflows/render-report-reusable.yaml
@@ -77,16 +77,16 @@ jobs:
       GITHUB_PAT: ${{ secrets.GH_DASH_REPOS || github.token }}
     steps:
       - name: Mint cm-operations-bot App token
-        if: ${{ secrets.CM_BOT_APP_ID != '' && secrets.CM_BOT_PRIVATE_KEY != '' }}
         uses: actions/create-github-app-token@v1
         id: app-token
+        continue-on-error: true
         with:
           app-id: ${{ secrets.CM_BOT_APP_ID }}
           private-key: ${{ secrets.CM_BOT_PRIVATE_KEY }}
           owner: Gilead-BioStats
 
       - name: Set effective token
-        if: ${{ secrets.CM_BOT_APP_ID != '' && secrets.CM_BOT_PRIVATE_KEY != '' }}
+        if: steps.app-token.outcome == 'success'
         shell: bash
         run: echo "GITHUB_PAT=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
 

--- a/.github/workflows/render-report-reusable.yaml
+++ b/.github/workflows/render-report-reusable.yaml
@@ -6,6 +6,12 @@ on:
       GH_DASH_REPOS:
         description: 'PAT with repo access for fetching private repository data (optional, falls back to github.token)'
         required: false
+      CM_BOT_APP_ID:
+        description: 'GitHub App ID for cm-operations-bot (optional, takes precedence over GH_DASH_REPOS when provided with CM_BOT_PRIVATE_KEY)'
+        required: false
+      CM_BOT_PRIVATE_KEY:
+        description: 'GitHub App private key for cm-operations-bot (optional, takes precedence over GH_DASH_REPOS when provided with CM_BOT_APP_ID)'
+        required: false
     inputs:
       ref:
         description: Git reference or SHA to check out
@@ -70,6 +76,20 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GH_DASH_REPOS || github.token }}
     steps:
+      - name: Mint cm-operations-bot App token
+        if: ${{ secrets.CM_BOT_APP_ID != '' && secrets.CM_BOT_PRIVATE_KEY != '' }}
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.CM_BOT_APP_ID }}
+          private-key: ${{ secrets.CM_BOT_PRIVATE_KEY }}
+          owner: Gilead-BioStats
+
+      - name: Set effective token
+        if: ${{ secrets.CM_BOT_APP_ID != '' && secrets.CM_BOT_PRIVATE_KEY != '' }}
+        shell: bash
+        run: echo "GITHUB_PAT=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
+
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
@@ -112,7 +132,7 @@ jobs:
         with:
           repository: ${{ inputs.qual-repo }}
           ref: main
-          token: ${{ secrets.GH_DASH_REPOS || github.token }}
+          token: ${{ steps.app-token.outputs.token || secrets.GH_DASH_REPOS || github.token }}
           sparse-checkout: |
             ${{ inputs.qual-path }}
           path: registry


### PR DESCRIPTION
Closes #46

## Changes

Added two optional secrets to `render-report-reusable.yaml`:
- `CM_BOT_APP_ID`
- `CM_BOT_PRIVATE_KEY`

When both are provided, the workflow mints an installation token via `actions/create-github-app-token@v1` (owner: `Gilead-BioStats`) and overrides `GITHUB_PAT` and the qualification-registry checkout token with it. When neither is provided, existing behaviour is unchanged (`GH_DASH_REPOS || github.token`).

## Why

GitHub Actions does not allow `needs.<job>.outputs` as values in a `secrets:` mapping for `workflow_call` jobs — only values from the `secrets` context are accepted. This means callers cannot mint a token externally and forward it; the token must be minted inside the reusable workflow using actual org secrets.

## Caller usage after this change

```yaml
jobs:
  render:
    uses: Gilead-BioStats/gh.dash/.github/workflows/render-report-reusable.yaml@main
    with:
      ref: ${{ github.ref_name }}
      title: "{gsm}"
      qual-repo: "Gilead-BioStats/r-qualification"
      qual-path: "qualified-releases.csv"
    secrets:
      CM_BOT_APP_ID: ${{ secrets.CM_BOT_APP_ID }}
      CM_BOT_PRIVATE_KEY: ${{ secrets.CM_BOT_PRIVATE_KEY }}
```